### PR TITLE
Updates git status check to look for directory and tree

### DIFF
--- a/mkdist.sh
+++ b/mkdist.sh
@@ -11,7 +11,7 @@ EOF
 	exit 0
 }
 
-git status | grep -q "nothing to commit, working tree clean"
+git status | grep -qE "nothing to commit, working directory|tree clean"
 if [ $? -ne 0 ]
 then
 	echo "Your working tree isn't clean, aborting build"


### PR DESCRIPTION
On my workstation (Ubuntu 14.04 LTS, git version 1.5.0) I noticed that running `mkdist.sh` failed because the grep was looking for "...working tree clean" and my git was outputting "...working directory clean". I've updated the grep to use extended regex and look for directory and tree.
