### PR TITLE
Add message delay loop

### DIFF
--- a/connectors/slack/connect.go
+++ b/connectors/slack/connect.go
@@ -93,6 +93,7 @@ Loop:
 	sc.botFullName = sc.userInfo[sc.botName].RealName
 	sc.SetFullName(sc.botFullName)
 	sc.Log(bot.Debug, "Set bot full name to", sc.botFullName)
+	go sc.startSendLoop()
 
 	return bot.Connector(sc)
 }


### PR DESCRIPTION
When nlopes/slack switched to gorilla websocket, it highlighted
a bug in Gopherbot where the robot was sending messages too fast
and being rate limited by Slack. Previously the library was
transparently reconnecting and sending the message, so the bug
wasn't apparent. This patch creates a sendMessages infinite loop
goroutine that insures a 1 second delay after every message, to
avoid hitting the rate limit.