### PR TITLE
Improved debugging & config loading

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,23 +1,18 @@
 - Look up new Bot IDs on the fly if a new bot ID is seen; need to add locking of the bots[] map
 - Move slack send loop into anon func in Run
 - Fix slack user attribute == user
-- Use globalLock for protocolConfig, brainConfig, elevateConfig
-
-For testing:
-- Emit error values to channel for testing:
- - When a user is ignored
- - When auth/elevate fails
- - When a command doesn't match anything (wrong user / channel or typo)
-- Create comprehensive test loop / table tests
+- Consider: Use globalLock for protocolConfig, brainConfig, elevateConfig
 - Add SendBotMessage() and GetBotMessage() methods for Slack in a conditional
   compilation connector_testing.go ala GetEvents - see emit_testing.go; use for
   connecting to slack and immediately quitting
 - Documentation for events, emit, development and testing - Developing.md
 - Unit tests for updateRegexes
-- Auth & elevator should trust using plugins (or trust all)
 - Stop hard-coding 'it' for contexts; 'server:it:the server' instead of
   'server', (context followed by generics that match); e.g. "reboot server",
   "reboot the server", "reboot it" would all check the "server" short-term
   memory to get e.g. "webtest1.example.com"
 - Add more sample transcripts to documentation using the terminal connector
 - The 'catchall' plugin should be in gopherbot.yaml (There Can Be Only One)
+- Consider: should configuration loading record all explicit values, with
+  intentional defaults when nothing configured explicitly? (probably yes,
+  instead of always using the zero-values of the type)

--- a/bot/authorize.go
+++ b/bot/authorize.go
@@ -10,7 +10,7 @@ func (bot *Robot) checkAuthorization(plugins []*Plugin, plugin *Plugin, command 
 	if !(plugin.AuthorizeAllCommands || len(plugin.AuthorizedCommands) > 0) {
 		// This plugin requires no authorization
 		if plugin.Authorizer != "" {
-			Log(Audit, fmt.Sprintf("Plugin \"%s\" configured an authorizer, but has no commands requiring authorization", plugin.name))
+			Log(Audit, fmt.Sprintf("Plugin '%s' configured an authorizer, but has no commands requiring authorization", plugin.name))
 			bot.Say(configAuthError)
 			return ConfigurationError
 		}
@@ -31,7 +31,7 @@ func (bot *Robot) checkAuthorization(plugins []*Plugin, plugin *Plugin, command 
 	defaultAuthorizer := robot.defaultAuthorizer
 	robot.RUnlock()
 	if plugin.Authorizer == "" && defaultAuthorizer == "" {
-		Log(Audit, fmt.Sprintf("Plugin \"%s\" requires authorization for command \"%s\", but no authorizer configured", plugin.name, command))
+		Log(Audit, fmt.Sprintf("Plugin '%s' requires authorization for command '%s', but no authorizer configured", plugin.name, command))
 		bot.Say(configAuthError)
 		emit(AuthNoRunMisconfigured)
 		return ConfigurationError
@@ -45,34 +45,34 @@ func (bot *Robot) checkAuthorization(plugins []*Plugin, plugin *Plugin, command 
 		args = append([]string{plugin.name, plugin.AuthRequire, command}, args...)
 		authRet := callPlugin(bot, authPlug, false, false, "authorize", args...)
 		if authRet == Success {
-			Log(Audit, fmt.Sprintf("Authorization succeeded by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			Log(Audit, fmt.Sprintf("Authorization succeeded by authorizer '%s' for user '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 			emit(AuthRanSuccess)
 			return Success
 		}
 		if authRet == Fail {
-			Log(Audit, fmt.Sprintf("Authorization FAILED by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			Log(Audit, fmt.Sprintf("Authorization FAILED by authorizer '%s' for user '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 			bot.Say("Sorry, you're not authorized for that command in this channel")
 			emit(AuthRanFail)
 			return Fail
 		}
 		if authRet == MechanismFail {
-			Log(Audit, fmt.Sprintf("Auth plugin \"%s\" mechanism failure while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			Log(Audit, fmt.Sprintf("Auth plugin '%s' mechanism failure while authenticating user '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 			bot.Say(technicalAuthError)
 			emit(AuthRanMechanismFailed)
 			return MechanismFail
 		}
 		if authRet == Normal {
-			Log(Audit, fmt.Sprintf("Auth plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing auth in \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			Log(Audit, fmt.Sprintf("Auth plugin '%s' returned 'Normal' (0) instead of 'Success' (1), failing auth in '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 			bot.Say(technicalAuthError)
 			emit(AuthRanFailNormal)
 			return MechanismFail
 		}
-		Log(Audit, fmt.Sprintf("Auth plugin \"%s\" exit code %d, failing auth while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, authRet, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+		Log(Audit, fmt.Sprintf("Auth plugin '%s' exit code %s, failing auth while authenticating user '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", authPlug.name, authRet, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 		bot.Say(technicalAuthError)
 		emit(AuthRanFailOther)
 		return MechanismFail
 	}
-	Log(Audit, fmt.Sprintf("Auth plugin \"%s\" not found while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", plugin.Authorizer, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+	Log(Audit, fmt.Sprintf("Auth plugin '%s' not found while authenticating user '%s' calling command '%s' for plugin '%s' in channel '%s'; AuthRequire: '%s'", plugin.Authorizer, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 	bot.Say(technicalAuthError)
 	emit(AuthNoRunNotFound)
 	return ConfigurationError

--- a/bot/authorize.go
+++ b/bot/authorize.go
@@ -42,7 +42,7 @@ func (bot *Robot) checkAuthorization(plugins []*Plugin, plugin *Plugin, command 
 	}
 	for _, authPlug := range plugins {
 		if authorizer == authPlug.name {
-			if !bot.pluginAvailable(authPlug, false) {
+			if !bot.pluginAvailable(authPlug, false, true) {
 				Log(Audit, fmt.Sprintf("Auth plugin \"%s\" not available while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 				bot.Say(configAuthError)
 				emit(AuthNoRunPlugNotAvailable)

--- a/bot/authorize.go
+++ b/bot/authorize.go
@@ -40,44 +40,37 @@ func (bot *Robot) checkAuthorization(plugins []*Plugin, plugin *Plugin, command 
 	if plugin.Authorizer != "" {
 		authorizer = plugin.Authorizer
 	}
-	for _, authPlug := range plugins {
-		if authorizer == authPlug.name {
-			if !bot.pluginAvailable(authPlug, false, true) {
-				Log(Audit, fmt.Sprintf("Auth plugin \"%s\" not available while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
-				bot.Say(configAuthError)
-				emit(AuthNoRunPlugNotAvailable)
-				return ConfigurationError
-			}
-			args = append([]string{plugin.name, plugin.AuthRequire, command}, args...)
-			authRet := callPlugin(bot, authPlug, false, false, "authorize", args...)
-			if authRet == Success {
-				Log(Audit, fmt.Sprintf("Authorization succeeded by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
-				emit(AuthRanSuccess)
-				return Success
-			}
-			if authRet == Fail {
-				Log(Audit, fmt.Sprintf("Authorization FAILED by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
-				bot.Say("Sorry, you're not authorized for that command in this channel")
-				emit(AuthRanFail)
-				return Fail
-			}
-			if authRet == MechanismFail {
-				Log(Audit, fmt.Sprintf("Auth plugin \"%s\" mechanism failure while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
-				bot.Say(technicalAuthError)
-				emit(AuthRanMechanismFailed)
-				return MechanismFail
-			}
-			if authRet == Normal {
-				Log(Audit, fmt.Sprintf("Auth plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing auth in \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
-				bot.Say(technicalAuthError)
-				emit(AuthRanFailNormal)
-				return MechanismFail
-			}
-			Log(Audit, fmt.Sprintf("Auth plugin \"%s\" exit code %d, failing auth while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, authRet, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+	authPlug := currentPlugins.getPluginByName(authorizer)
+	if authPlug != nil {
+		args = append([]string{plugin.name, plugin.AuthRequire, command}, args...)
+		authRet := callPlugin(bot, authPlug, false, false, "authorize", args...)
+		if authRet == Success {
+			Log(Audit, fmt.Sprintf("Authorization succeeded by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			emit(AuthRanSuccess)
+			return Success
+		}
+		if authRet == Fail {
+			Log(Audit, fmt.Sprintf("Authorization FAILED by authorizer \"%s\" for user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			bot.Say("Sorry, you're not authorized for that command in this channel")
+			emit(AuthRanFail)
+			return Fail
+		}
+		if authRet == MechanismFail {
+			Log(Audit, fmt.Sprintf("Auth plugin \"%s\" mechanism failure while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 			bot.Say(technicalAuthError)
-			emit(AuthRanFailOther)
+			emit(AuthRanMechanismFailed)
 			return MechanismFail
 		}
+		if authRet == Normal {
+			Log(Audit, fmt.Sprintf("Auth plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing auth in \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+			bot.Say(technicalAuthError)
+			emit(AuthRanFailNormal)
+			return MechanismFail
+		}
+		Log(Audit, fmt.Sprintf("Auth plugin \"%s\" exit code %d, failing auth while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", authPlug.name, authRet, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
+		bot.Say(technicalAuthError)
+		emit(AuthRanFailOther)
+		return MechanismFail
 	}
 	Log(Audit, fmt.Sprintf("Auth plugin \"%s\" not found while authenticating user \"%s\" calling command \"%s\" for plugin \"%s\" in channel \"%s\"; AuthRequire: \"%s\"", plugin.Authorizer, bot.User, command, plugin.name, bot.Channel, plugin.AuthRequire))
 	bot.Say(technicalAuthError)

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -45,7 +45,7 @@ func RegisterConnector(name string, connstarter func(Handler, *log.Logger) Conne
 // by loadConfig, other stuff is populated by the connector.
 var robot struct {
 	Connector                           // Connector interface, implemented by each specific protocol
-	configPath          string           // Directory for local files overriding default config
+	configPath         string           // Directory for local files overriding default config
 	installPath        string           // Path to the bot's installation directory
 	adminUsers         []string         // List of users with access to administrative commands
 	alias              rune             // single-char alias for addressing the bot

--- a/bot/bot_integration_test.go
+++ b/bot/bot_integration_test.go
@@ -153,6 +153,10 @@ func TestBotName(t *testing.T) {
 	done, conn := setup("cfg/test/membrain", "/tmp/bottest.log", t)
 
 	tests := []testItem{
+		{alice, null, "ping, bender", []testc.TestMessage{{alice, null, "PONG"}}, []Event{BotDirectMessage, CommandPluginRan, GoPluginRan}, 0},
+		{alice, null, ";ping", []testc.TestMessage{{alice, null, "PONG"}}, []Event{BotDirectMessage, CommandPluginRan, GoPluginRan}, 0},
+		{alice, null, "bender ping", []testc.TestMessage{{alice, null, "PONG"}}, []Event{BotDirectMessage, CommandPluginRan, GoPluginRan}, 0},
+		{alice, null, "ping", []testc.TestMessage{{alice, null, "PONG"}}, []Event{BotDirectMessage, CommandPluginRan, GoPluginRan}, 0},
 		{alice, general, "ping, bender", []testc.TestMessage{{alice, general, "PONG"}}, []Event{CommandPluginRan, GoPluginRan}, 0},
 		{alice, general, ";ping", []testc.TestMessage{{alice, general, "PONG"}}, []Event{CommandPluginRan, GoPluginRan}, 0},
 		{alice, general, "bender ping", []testc.TestMessage{{alice, general, "PONG"}}, []Event{CommandPluginRan, GoPluginRan}, 0},

--- a/bot/builtins.go
+++ b/bot/builtins.go
@@ -301,10 +301,12 @@ func admin(bot *Robot, command string, args ...string) (retval PlugRetVal) {
 		pd := &debuggingPlug{
 			pluginID: p,
 			name:     args[0],
+			user:     bot.User,
 			verbose:  verbose,
 		}
 		plugDebug.Lock()
-		plugDebug.p[bot.User] = pd
+		plugDebug.p[p] = pd
+		plugDebug.u[bot.User] = pd
 		plugDebug.Unlock()
 		err := bot.loadConfig()
 		if err != nil {
@@ -315,7 +317,11 @@ func admin(bot *Robot, command string, args ...string) (retval PlugRetVal) {
 		bot.Say(fmt.Sprintf("Debugging enabled for %s", args[0]))
 	case "stop":
 		plugDebug.Lock()
-		delete(plugDebug.p, bot.User)
+		pd, ok := plugDebug.u[bot.User]
+		if ok {
+			delete(plugDebug.p, pd.pluginID)
+			delete(plugDebug.u, bot.User)
+		}
 		plugDebug.Unlock()
 		bot.Say("Debugging disabled")
 	case "quit":

--- a/bot/builtins.go
+++ b/bot/builtins.go
@@ -314,14 +314,8 @@ func admin(bot *Robot, command string, args ...string) (retval PlugRetVal) {
 			bot.Say(fmt.Sprintf("Invalid plugin name '%s', doesn't match regexp: '%s' (plugin can't load)", pname, pNameRe.String()))
 			return
 		}
-		var plugin *Plugin
-		currentPlugins.RLock()
-		i, found := currentPlugins.nameMap[pname]
-		if found {
-			plugin = currentPlugins.p[i]
-		}
-		currentPlugins.RUnlock()
-		if !found {
+		plugin := currentPlugins.getPluginByName(pname)
+		if plugin == nil {
 			bot.Say("I don't have any plugins with that name configured")
 			return
 		}

--- a/bot/builtins.go
+++ b/bot/builtins.go
@@ -330,7 +330,7 @@ func admin(bot *Robot, command string, args ...string) (retval PlugRetVal) {
 			return
 		}
 		verbose := false
-		if len(args) == 2 && args[1] == "verbose" {
+		if len(args[1]) > 0 {
 			verbose = true
 		}
 		bot.Log(Debug, fmt.Sprintf("Enabling debugging for %s (%s), verbose: %v", pname, plugin.pluginID, verbose))
@@ -350,7 +350,7 @@ func admin(bot *Robot, command string, args ...string) (retval PlugRetVal) {
 			Log(Error, fmt.Errorf("Reloading configuration, requested by %s: %v", bot.User, err))
 			return
 		}
-		bot.Say(fmt.Sprintf("Debugging enabled for %s", args[0]))
+		bot.Say(fmt.Sprintf("Debugging enabled for %s (verbose: %v)", args[0], verbose))
 	case "stop":
 		plugDebug.Lock()
 		pd, ok := plugDebug.u[bot.User]

--- a/bot/builtinsDefaultConfig.go
+++ b/bot/builtinsDefaultConfig.go
@@ -47,12 +47,12 @@ Help:
 - Keywords: [ "dump", "plugin" ]
   Helptext: [ "(bot), dump plugin (default) <plugname> - dump the current or default configuration for the plugin" ]
 - Keywords: [ "list", "plugin", "plugins" ]
-  Helptext: [ "(bot), list plugins" ]
+  Helptext: [ "(bot), list (disabled) plugins - list all known plugins, or list disabled plugins with the reason disabled" ]
 - Keywords: [ "dump", "robot" ]
   Helptext: [ "(bot), dump robot - dump the current configuration for the robot" ]
 CommandMatchers:
 - Command: "list"
-  Regex: '(?i:list plugins?)'
+  Regex: '(?i:list( disabled)? plugins?)'
 - Command: "plugdefault"
   Regex: '(?i:dump plugin default ([\d\w-.]+))'
 - Command: "plugin"

--- a/bot/builtinsDefaultConfig.go
+++ b/bot/builtinsDefaultConfig.go
@@ -24,7 +24,7 @@ Help:
 - Keywords: [ "abort" ]
   Helptext: [ "(bot), abort - request an immediate shutdown without waiting for plugins to finish" ]
 - Keywords: [ "debug" ]
-  Helptext: [ "(bot), debug plugin <pluginname> - turn on debugging for the named plugin" ]
+  Helptext: [ "(bot), debug plugin <pluginname> (verbose) - turn on debugging for the named plugin, optionally verbose" ]
 - Keywords: [ "debug" ]
   Helptext: [ "(bot), stop debugging - turn off debugging" ]
 CommandMatchers:

--- a/bot/callplugin.go
+++ b/bot/callplugin.go
@@ -137,8 +137,14 @@ func getExtDefCfg(plugin *Plugin) (*[]byte, error) {
 	return &cfg, nil
 }
 
-// callPlugin (normally called with go ...) sends a command to a plugin.
+// callPlugin does the real work of running a plugin with a command and arguments.
 func callPlugin(bot *Robot, plugin *Plugin, background bool, interactive bool, command string, args ...string) (retval PlugRetVal) {
+	if plugin.Disabled {
+		msg := fmt.Sprintf("Call plugin failed on disabled plugin %s; reason: %s", plugin.name, plugin.reason)
+		bot.Log(Error, msg)
+		bot.debug(bot.pluginID, msg, false)
+		return ConfigurationError
+	}
 	if background {
 		robot.Add(1)
 		robot.Lock()

--- a/bot/callplugin.go
+++ b/bot/callplugin.go
@@ -166,7 +166,7 @@ func callPlugin(bot *Robot, plugin *Plugin, background bool, interactive bool, c
 	Log(Debug, fmt.Sprintf("Dispatching command \"%s\" to plugin \"%s\" with arguments \"%#v\"", command, plugin.name, args))
 	bot.pluginID = plugin.pluginID
 	switch plugin.pluginType {
-	case plugBuiltin, plugGo:
+	case plugGo:
 		if command != "init" {
 			emit(GoPluginRan)
 		}

--- a/bot/conf.go
+++ b/bot/conf.go
@@ -138,7 +138,7 @@ func (r *Robot) loadConfig() error {
 		var sarrval []string
 		var epval []externalPlugin
 		var mailval botMailer
-		var boolval bool
+		var boolval *bool
 		var intval int
 		var val interface{}
 		skip := false
@@ -191,7 +191,12 @@ func (r *Robot) loadConfig() error {
 		case "Name":
 			newconfig.Name = *(val.(*string))
 		case "DefaultAllowDirect":
-			newconfig.DefaultAllowDirect = *(val.(*bool))
+			bptr := *(val.(**bool))
+			if bptr == nil {
+				newconfig.DefaultAllowDirect = false
+			} else {
+				newconfig.DefaultAllowDirect = *bptr
+			}
 		case "DefaultChannels":
 			newconfig.DefaultChannels = *(val.(*[]string))
 		case "IgnoreUsers":

--- a/bot/conf.go
+++ b/bot/conf.go
@@ -15,10 +15,6 @@ import (
 
 var protocolConfig, brainConfig, elevateConfig json.RawMessage
 
-type externalPlugin struct {
-	Name, Path string // List of names and paths for external plugins; relative paths are searched first in installpath, then configpath
-}
-
 // botconf specifies 'bot configuration, and is read from $GOPHER_CONFIGDIR/conf/gopherbot.yaml
 type botconf struct {
 	AdminContact       string           // Contact info for whomever administers the robot
@@ -68,7 +64,6 @@ func (r *Robot) getConfigFile(filename, pluginID string, required bool, jsonMap 
 	if err == nil {
 		r.debug(pluginID, fmt.Sprintf("Loaded configuration from installPath (%s), size: %d", path, len(cf)), false)
 		if err = yaml.Unmarshal(cf, &loader); err != nil {
-			r.debug(pluginID, fmt.Sprintf("Error unmarshalling %s: %v", path, err), false)
 			err = fmt.Errorf("Unmarshalling installed \"%s\": %v", filename, err)
 			Log(Error, err)
 			return err
@@ -95,8 +90,7 @@ func (r *Robot) getConfigFile(filename, pluginID string, required bool, jsonMap 
 		if err == nil {
 			r.debug(pluginID, fmt.Sprintf("Loaded configuration from configPath (%s), size: %d", path, len(cf)), false)
 			if err = yaml.Unmarshal(cf, &loader); err != nil {
-				r.debug(pluginID, fmt.Sprintf("Error unmarshalling %s: %v", path, err), false)
-				err = fmt.Errorf("Unmarshalling local \"%s\": %v", filename, err)
+				err = fmt.Errorf("Unmarshalling configured \"%s\": %v", filename, err)
 				Log(Error, err)
 				return err // If a badly-formatted config is loaded, we always return an error
 			}

--- a/bot/conf.go
+++ b/bot/conf.go
@@ -126,13 +126,14 @@ func (r *Robot) loadConfig() error {
 	if err := r.getConfigFile("gopherbot.yaml", "", true, configload); err != nil {
 		return fmt.Errorf("Loading configuration file: %v", err)
 	}
+	explicitDefaultAllowDirect := false
 
 	for key, value := range configload {
 		var strval string
 		var sarrval []string
 		var epval []externalPlugin
 		var mailval botMailer
-		var boolval *bool
+		var boolval bool
 		var intval int
 		var val interface{}
 		skip := false
@@ -185,12 +186,8 @@ func (r *Robot) loadConfig() error {
 		case "Name":
 			newconfig.Name = *(val.(*string))
 		case "DefaultAllowDirect":
-			bptr := *(val.(**bool))
-			if bptr == nil {
-				newconfig.DefaultAllowDirect = false
-			} else {
-				newconfig.DefaultAllowDirect = *bptr
-			}
+			newconfig.DefaultAllowDirect = *(val.(*bool))
+			explicitDefaultAllowDirect = true
 		case "DefaultChannels":
 			newconfig.DefaultChannels = *(val.(*[]string))
 		case "IgnoreUsers":
@@ -232,10 +229,16 @@ func (r *Robot) loadConfig() error {
 		protocolConfig = newconfig.ProtocolConfig
 	}
 
-	robot.defaultAllowDirect = newconfig.DefaultAllowDirect // defaults to false
+	if explicitDefaultAllowDirect {
+		robot.defaultAllowDirect = newconfig.DefaultAllowDirect
+	} else {
+		robot.defaultAllowDirect = true // rare case of defaulting to true
+	}
+
 	if newconfig.AdminContact != "" {
 		robot.adminContact = newconfig.AdminContact
 	}
+
 	if newconfig.Email != "" {
 		robot.email = newconfig.Email
 	}

--- a/bot/debug.go
+++ b/bot/debug.go
@@ -65,5 +65,7 @@ func (r *Robot) debug(pluginID, msg string, verboseonly bool) {
 		plugName = ppd.name
 	}
 	ts := time.Now().Format("2006/01/02 03:04:05")
-	r.SendUserMessage(targetUser, fmt.Sprintf("%s DEBUG %s: %s", ts, plugName, msg))
+	debugLog := fmt.Sprintf("%s DEBUG %s: %s", ts, plugName, msg)
+	r.SendUserMessage(targetUser, debugLog)
+	// r.Log(Debug, debugLog)
 }

--- a/bot/debug.go
+++ b/bot/debug.go
@@ -27,13 +27,13 @@ var plugDebug = struct {
 	sync.RWMutex{},
 }
 
-// If the debug statement specifies verbose, then the user will only get the
+// If the debug statement requests verboseonly, then the user will only get the
 // message if verbose debugging was requested.
-func (r *Robot) debug(pluginID, msg string, verbose bool) {
+func (r *Robot) debug(pluginID, msg string, verboseonly bool) {
 	if len(pluginID) == 0 && len(r.User) == 0 {
 		return
 	}
-	if len(pluginID) == 0 && !verbose {
+	if len(pluginID) == 0 && !verboseonly {
 		return
 	}
 	plugDebug.RLock()
@@ -53,8 +53,11 @@ func (r *Robot) debug(pluginID, msg string, verbose bool) {
 		targetUser = upd.user
 		plugName = upd.name
 	} else {
+		if len(pluginID) > 0 && ppd.pluginID != pluginID {
+			return // should only be true for help requests, or authorization / elevation plugin actions
+		}
 		// If we look up by plugin, users don't need to match if verbose is true
-		if ppd.user != r.User && !(verbose && ppd.verbose) {
+		if ppd.user != r.User && !(verboseonly && ppd.verbose) {
 			return
 		}
 		// We know the plugin, and if users don't match it's verbose

--- a/bot/debug.go
+++ b/bot/debug.go
@@ -13,33 +13,54 @@ import (
 )
 
 type debuggingPlug struct {
-	pluginID, name string // the ID and name of the plugin being debugged
-	verbose        bool   // do we want feedback for every message the user types?
+	pluginID, name, user string // the ID and name of the plugin being debugged, user requesting
+	verbose              bool   // do we want feedback for every message the user types?
 }
 
 var plugDebug = struct {
-	p map[string]*debuggingPlug // map username to plugin being debugged
+	p map[string]*debuggingPlug // map of pluginID to the debuggingPlug struct
+	u map[string]*debuggingPlug // map of user to the debuggingPlug struct
 	sync.RWMutex
 }{
+	make(map[string]*debuggingPlug),
 	make(map[string]*debuggingPlug),
 	sync.RWMutex{},
 }
 
-func (r *Robot) debug(pluginID, msg string, everyMsg bool) {
-	if len(r.User) == 0 {
+// If the debug statement specifies verbose, then the user will only get the
+// message if verbose debugging was requested.
+func (r *Robot) debug(pluginID, msg string, verbose bool) {
+	if len(pluginID) == 0 && len(r.User) == 0 {
 		return
 	}
-	if len(pluginID) == 0 && !everyMsg {
+	if len(pluginID) == 0 && !verbose {
 		return
 	}
 	plugDebug.RLock()
-	up, ok := plugDebug.p[r.User]
+	ppd, _ := plugDebug.p[pluginID]
+	upd, _ := plugDebug.u[r.User]
 	plugDebug.RUnlock()
-	if !ok {
-		return
+	var targetUser, plugName string
+	if ppd == nil {
+		if upd == nil {
+			return
+		}
+		// If we can't look up by plugin, and users don't match, we never care
+		if upd.user != r.User {
+			return
+		}
+		// User has spoken but the plugin wasn't determined yet
+		targetUser = upd.user
+		plugName = upd.name
+	} else {
+		// If we look up by plugin, users don't need to match if verbose is true
+		if ppd.user != r.User && !(verbose && ppd.verbose) {
+			return
+		}
+		// We know the plugin, and if users don't match it's verbose
+		targetUser = ppd.user
+		plugName = ppd.name
 	}
-	if (pluginID == up.pluginID) || (everyMsg && up.verbose) {
-		ts := time.Now().Format("2006/01/02 03:04:05")
-		r.SendUserMessage(r.User, fmt.Sprintf("%s DEBUG %s: %s", ts, up.name, msg))
-	}
+	ts := time.Now().Format("2006/01/02 03:04:05")
+	r.SendUserMessage(targetUser, fmt.Sprintf("%s DEBUG %s: %s", ts, plugName, msg))
 }

--- a/bot/debug.go
+++ b/bot/debug.go
@@ -45,19 +45,42 @@ func (r *Robot) debug(pluginID, msg string, verboseonly bool) {
 		if upd == nil {
 			return
 		}
+		// Cases where the user is debugging but not the given plugin
+
+		if verboseonly && !upd.verbose {
+			return
+		}
 		// If we can't look up by plugin, and users don't match, we never care
 		if upd.user != r.User {
+			return
+		}
+		// We never care about a plugin that's not being debugged
+		if len(pluginID) > 0 {
 			return
 		}
 		// User has spoken but the plugin wasn't determined yet
 		targetUser = upd.user
 		plugName = upd.name
 	} else {
-		if len(pluginID) > 0 && ppd.pluginID != pluginID {
-			return // should only be true for help requests, or authorization / elevation plugin actions
+		// Cases where the given plugin is being debugged, but not necessarily
+		// by the user that triggered the debug statement.
+		// r.Log(Trace, fmt.Sprintf("REMOVE: name: %s, user: %s, verboseonly: %v", ppd.name, r.User, verboseonly))
+
+		if verboseonly && !ppd.verbose {
+			return
 		}
-		// If we look up by plugin, users don't need to match if verbose is true
-		if ppd.user != r.User && !(verboseonly && ppd.verbose) {
+		if ppd.user != r.User {
+			// If users don't match and verboseonly requested, don't debug
+			if verboseonly {
+				return
+			}
+			// If debugging verbose, debug non-verboseonly messages
+			if !ppd.verbose {
+				return
+			}
+		}
+		if len(pluginID) > 0 && ppd.pluginID != pluginID {
+			// should only be true when checking availability for help requests, authorization, or elevation plugins
 			return
 		}
 		// We know the plugin, and if users don't match it's verbose

--- a/bot/dispatch.go
+++ b/bot/dispatch.go
@@ -22,13 +22,16 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 		directMsg = true
 	}
 	if !directMsg && plugin.DirectOnly && !helpSystem {
+		r.debug(plugin.pluginID, "plugin is NOT visible; only available by direct message: DirectOnly is TRUE", false)
 		return false
 	}
-	if directMsg && plugin.DenyDirect && !helpSystem {
+	if directMsg && !plugin.AllowDirect && !helpSystem {
+		r.debug(plugin.pluginID, "plugin is NOT visible; not available by direct message: AllowDirect is FALSE", false)
 		return false
 	}
-	if plugin.DirectOnly && plugin.DenyDirect {
-		Log(Error, fmt.Sprintf("Plugin %s has conflicting DirectOnly and DenyDirect both true", plugin.name))
+	if plugin.DirectOnly && !plugin.AllowDirect {
+		Log(Error, fmt.Sprintf("Plugin %s has conflicting DirectOnly = true and AllowDirect = false", plugin.name))
+		r.debug(plugin.pluginID, "plugin is NOT visible; conflicting DirectOnly = true and AllowDirect = false", false)
 		return false
 	}
 	if plugin.RequireAdmin {
@@ -42,6 +45,7 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 		}
 		robot.RUnlock()
 		if !isAdmin {
+			r.debug(plugin.pluginID, "plugin is NOT visible; RequireAdmin is TRUE and user isn't an Admin", false)
 			return false
 		}
 	}

--- a/bot/dispatch.go
+++ b/bot/dispatch.go
@@ -10,28 +10,39 @@ const keepListeningDuration = 77 * time.Second
 
 // pluginAvailable checks the user and channel against the plugin's
 // configuration to determine if the message should be evaluated. Used by
-// both handleMessage and the help builtin.
-func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool) {
-	defer func() {
-		if !available {
-			r.debug(plugin.pluginID, "plugin is NOT visible; try 'help dump' to view plugin settings", false)
-		}
-	}()
-	directMsg := false
-	if len(r.Channel) == 0 {
-		directMsg = true
+// both handleMessage and the help builtin. verboseOnly is set when availability
+// is being checked for ambient messages or auth/elevation plugins, to indicate
+// debugging verboseness.
+func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem, verboseOnly bool) (available bool) {
+	nvmsg := "plugin is NOT visible to user " + r.User + " in channel "
+	vmsg := "plugin is visible to user " + r.User + " in channel "
+	if r.directMsg {
+		nvmsg += "(direct message)"
+		vmsg += "(direct message)"
+	} else {
+		nvmsg += r.Channel
+		vmsg += r.Channel
 	}
-	if !directMsg && plugin.DirectOnly && !helpSystem {
-		r.debug(plugin.pluginID, "plugin is NOT visible; only available by direct message: DirectOnly is TRUE", false)
+	defer func(vmsg string) {
+		if available {
+			r.debug(plugin.pluginID, vmsg, verboseOnly)
+		}
+	}(vmsg)
+	if plugin.Disabled {
+		r.debug(plugin.pluginID, nvmsg+"; plugin is disabled, possibly due to configuration error", verboseOnly)
 		return false
 	}
-	if directMsg && !plugin.AllowDirect && !helpSystem {
-		r.debug(plugin.pluginID, "plugin is NOT visible; not available by direct message: AllowDirect is FALSE", false)
+	if !r.directMsg && plugin.DirectOnly && !helpSystem {
+		r.debug(plugin.pluginID, nvmsg+"; only available by direct message: DirectOnly is TRUE", verboseOnly)
+		return false
+	}
+	if r.directMsg && !plugin.AllowDirect && !helpSystem {
+		r.debug(plugin.pluginID, nvmsg+"; not available by direct message: AllowDirect is FALSE", verboseOnly)
 		return false
 	}
 	if plugin.DirectOnly && !plugin.AllowDirect {
 		Log(Error, fmt.Sprintf("Plugin %s has conflicting DirectOnly = true and AllowDirect = false", plugin.name))
-		r.debug(plugin.pluginID, "plugin is NOT visible; conflicting DirectOnly = true and AllowDirect = false", false)
+		r.debug(plugin.pluginID, nvmsg+"; conflicting DirectOnly = true and AllowDirect = false", verboseOnly)
 		return false
 	}
 	if plugin.RequireAdmin {
@@ -45,7 +56,7 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 		}
 		robot.RUnlock()
 		if !isAdmin {
-			r.debug(plugin.pluginID, "plugin is NOT visible; RequireAdmin is TRUE and user isn't an Admin", false)
+			r.debug(plugin.pluginID, nvmsg+"; RequireAdmin is TRUE and user isn't an Admin", verboseOnly)
 			return false
 		}
 	}
@@ -58,10 +69,11 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 			}
 		}
 		if !userOk {
+			r.debug(plugin.pluginID, nvmsg+"; user is not on the list of allowed users", verboseOnly)
 			return false
 		}
 	}
-	if directMsg && (plugin.AllowDirect || plugin.DirectOnly) {
+	if r.directMsg && (plugin.AllowDirect || plugin.DirectOnly) {
 		return true
 	}
 	if len(plugin.Channels) > 0 {
@@ -78,6 +90,7 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 	if helpSystem {
 		return true
 	}
+	r.debug(plugin.pluginID, nvmsg+"; channel is not on the list of allowed channels", verboseOnly)
 	return false
 }
 
@@ -88,6 +101,8 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem bool) (available bool
 func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched bool) {
 	// un-needed, but more clear
 	commandMatched = false
+	// If we're checking messages, debugging messages require that the user requested verboseness
+	verboseOnly = !checkCommands
 	currentPlugins.RLock()
 	plugins := currentPlugins.p
 	currentPlugins.RUnlock()
@@ -95,8 +110,19 @@ func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched 
 	var matchedMatcher InputMatcher
 	var cmdArgs []string
 	for _, plugin := range plugins {
+		if checkCommands {
+			if len(plugin.CommandMatchers) == 0 {
+				bot.debug(plugin.pluginID, fmt.Sprintf("Plugin has no command matchers, skipping command check"), false)
+				return false
+			}
+		} else {
+			if len(plugin.MessageMatchers) == 0 {
+				bot.debug(plugin.pluginID, fmt.Sprintf("Plugin has no message matchers, skipping message check"), true)
+				return false
+			}
+		}
 		Log(Trace, fmt.Sprintf("Checking availability of plugin \"%s\" in channel \"%s\" for user \"%s\", active in %d channels (allchannels: %t)", plugin.name, bot.Channel, bot.User, len(plugin.Channels), plugin.AllChannels))
-		ok := bot.pluginAvailable(plugin, false)
+		ok := bot.pluginAvailable(plugin, false, verboseOnly)
 		if !ok {
 			Log(Trace, fmt.Sprintf("Plugin \"%s\" not available for user \"%s\" in channel \"%s\", doesn't meet criteria", plugin.name, bot.User, bot.Channel))
 			continue
@@ -112,16 +138,14 @@ func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched 
 			ctype = "message"
 		}
 		if len(matchers) > 0 {
-			bot.debug(plugin.pluginID, fmt.Sprintf("Checking %d %s matchers against message: \"%s\"", len(matchers), ctype, bot.msg), false)
-		} else {
-			bot.debug(plugin.pluginID, fmt.Sprintf("Plugin has no %s matchers, skipping", ctype), false)
+			bot.debug(plugin.pluginID, fmt.Sprintf("Checking %d %s matchers against message: \"%s\"", len(matchers), ctype, bot.msg), verboseOnly)
 		}
 		for _, matcher := range matchers {
 			Log(Trace, fmt.Sprintf("Checking \"%s\" against \"%s\"", bot.msg, matcher.Regex))
 			matches := matcher.re.FindAllStringSubmatch(bot.msg, -1)
 			var matched bool
 			if matches != nil {
-				bot.debug(plugin.pluginID, fmt.Sprintf("Matched regex '%s', command: %s", matcher.Regex, matcher.Command), false)
+				bot.debug(plugin.pluginID, fmt.Sprintf("Matched %s regex '%s', command: %s", ctype, matcher.Regex, matcher.Command), false)
 				matched = true
 				Log(Trace, fmt.Sprintf("Message \"%s\" matches command \"%s\"", bot.msg, matcher.Command))
 				cmdArgs = matches[0][1:]
@@ -156,7 +180,7 @@ func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched 
 					shortTermMemories.Unlock()
 				}
 			} else {
-				bot.debug(plugin.pluginID, fmt.Sprintf("Not matched: %s", matcher.Regex), false)
+				bot.debug(plugin.pluginID, fmt.Sprintf("Not matched: %s", matcher.Regex), verboseOnly)
 			}
 			if matched {
 				if commandMatched {

--- a/bot/dispatch.go
+++ b/bot/dispatch.go
@@ -91,7 +91,7 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem, verboseOnly bool) (a
 	if helpSystem {
 		return true
 	}
-	r.debug(plugin.pluginID, fmt.Sprintf(nvmsg+"; channel '%s' is not on the list of allowed channels: ", r.Channel, strings.Join(plugin.Channels, ", ")), verboseOnly)
+	r.debug(plugin.pluginID, fmt.Sprintf(nvmsg+"; channel '%s' is not on the list of allowed channels: %s", r.Channel, strings.Join(plugin.Channels, ", ")), verboseOnly)
 	return false
 }
 

--- a/bot/dispatch.go
+++ b/bot/dispatch.go
@@ -41,11 +41,6 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem, verboseOnly bool) (a
 		r.debug(plugin.pluginID, nvmsg+"; not available by direct message: AllowDirect is FALSE", verboseOnly)
 		return false
 	}
-	if plugin.DirectOnly && !plugin.AllowDirect {
-		Log(Error, fmt.Sprintf("Plugin %s has conflicting DirectOnly = true and AllowDirect = false", plugin.name))
-		r.debug(plugin.pluginID, nvmsg+"; conflicting DirectOnly = true and AllowDirect = false", verboseOnly)
-		return false
-	}
 	if plugin.RequireAdmin {
 		isAdmin := false
 		robot.RLock()

--- a/bot/dispatch.go
+++ b/bot/dispatch.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -90,7 +91,7 @@ func (r *Robot) pluginAvailable(plugin *Plugin, helpSystem, verboseOnly bool) (a
 	if helpSystem {
 		return true
 	}
-	r.debug(plugin.pluginID, nvmsg+"; channel is not on the list of allowed channels", verboseOnly)
+	r.debug(plugin.pluginID, fmt.Sprintf(nvmsg+"; channel '%s' is not on the list of allowed channels: ", r.Channel, strings.Join(plugin.Channels, ", ")), verboseOnly)
 	return false
 }
 
@@ -102,7 +103,7 @@ func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched 
 	// un-needed, but more clear
 	commandMatched = false
 	// If we're checking messages, debugging messages require that the user requested verboseness
-	verboseOnly = !checkCommands
+	verboseOnly := !checkCommands
 	currentPlugins.RLock()
 	plugins := currentPlugins.p
 	currentPlugins.RUnlock()
@@ -113,12 +114,12 @@ func (bot *Robot) checkPluginMatchersAndRun(checkCommands bool) (commandMatched 
 		if checkCommands {
 			if len(plugin.CommandMatchers) == 0 {
 				bot.debug(plugin.pluginID, fmt.Sprintf("Plugin has no command matchers, skipping command check"), false)
-				return false
+				continue
 			}
 		} else {
 			if len(plugin.MessageMatchers) == 0 {
 				bot.debug(plugin.pluginID, fmt.Sprintf("Plugin has no message matchers, skipping message check"), true)
-				return false
+				continue
 			}
 		}
 		Log(Trace, fmt.Sprintf("Checking availability of plugin \"%s\" in channel \"%s\" for user \"%s\", active in %d channels (allchannels: %t)", plugin.name, bot.Channel, bot.User, len(plugin.Channels), plugin.AllChannels))

--- a/bot/elevate.go
+++ b/bot/elevate.go
@@ -24,7 +24,7 @@ func (bot *Robot) elevate(plugins []*Plugin, plugin *Plugin, immediate bool) (re
 	}
 	for _, ePlug := range plugins {
 		if elevator == ePlug.name {
-			if !bot.pluginAvailable(ePlug, false) {
+			if !bot.pluginAvailable(ePlug, false, true) {
 				Log(Audit, fmt.Sprintf("Elevation plugin \"%s\" not available while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
 				bot.Say(configElevError)
 				emit(ElevNoRunNotAvailable)

--- a/bot/elevate.go
+++ b/bot/elevate.go
@@ -22,47 +22,40 @@ func (bot *Robot) elevate(plugins []*Plugin, plugin *Plugin, immediate bool) (re
 	if plugin.Elevator != "" {
 		elevator = plugin.Elevator
 	}
-	for _, ePlug := range plugins {
-		if elevator == ePlug.name {
-			if !bot.pluginAvailable(ePlug, false, true) {
-				Log(Audit, fmt.Sprintf("Elevation plugin \"%s\" not available while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
-				bot.Say(configElevError)
-				emit(ElevNoRunNotAvailable)
-				return ConfigurationError
-			}
-			immedString := "true"
-			if !immediate {
-				immedString = "false"
-			}
-			elevRet := callPlugin(bot, ePlug, false, false, "elevate", immedString)
-			if elevRet == Success {
-				Log(Audit, fmt.Sprintf("Elevation succeeded by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
-				emit(ElevRanSuccess)
-				return Success
-			}
-			if elevRet == Fail {
-				Log(Audit, fmt.Sprintf("Elevation FAILED by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
-				bot.Say("Sorry, this command requires elevation")
-				emit(ElevRanFail)
-				return Fail
-			}
-			if elevRet == MechanismFail {
-				Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" mechanism failure while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
-				bot.Say(technicalElevError)
-				emit(ElevRanMechanismFailed)
-				return MechanismFail
-			}
-			if elevRet == Normal {
-				Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing elevation in \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
-				bot.Say(technicalElevError)
-				emit(ElevRanFailNormal)
-				return MechanismFail
-			}
-			Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" exit code %d while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, retval, bot.User, plugin.name, bot.Channel))
+	ePlug := currentPlugins.getPluginByName(elevator)
+	if ePlug != nil {
+		immedString := "true"
+		if !immediate {
+			immedString = "false"
+		}
+		elevRet := callPlugin(bot, ePlug, false, false, "elevate", immedString)
+		if elevRet == Success {
+			Log(Audit, fmt.Sprintf("Elevation succeeded by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			emit(ElevRanSuccess)
+			return Success
+		}
+		if elevRet == Fail {
+			Log(Audit, fmt.Sprintf("Elevation FAILED by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			bot.Say("Sorry, this command requires elevation")
+			emit(ElevRanFail)
+			return Fail
+		}
+		if elevRet == MechanismFail {
+			Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" mechanism failure while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
 			bot.Say(technicalElevError)
-			emit(ElevRanFailOther)
+			emit(ElevRanMechanismFailed)
 			return MechanismFail
 		}
+		if elevRet == Normal {
+			Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing elevation in \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			bot.Say(technicalElevError)
+			emit(ElevRanFailNormal)
+			return MechanismFail
+		}
+		Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" exit code %d while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, retval, bot.User, plugin.name, bot.Channel))
+		bot.Say(technicalElevError)
+		emit(ElevRanFailOther)
+		return MechanismFail
 	}
 	Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" not found while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", plugin.Elevator, bot.User, plugin.name, bot.Channel))
 	bot.Say(technicalElevError)

--- a/bot/elevate.go
+++ b/bot/elevate.go
@@ -13,7 +13,7 @@ func (bot *Robot) elevate(plugins []*Plugin, plugin *Plugin, immediate bool) (re
 	defaultElevator := robot.defaultElevator
 	robot.RUnlock()
 	if plugin.Elevator == "" && defaultElevator == "" {
-		Log(Audit, fmt.Sprintf("Plugin \"%s\" requires elevation, but no elevator configured", plugin.name))
+		Log(Audit, fmt.Sprintf("Plugin '%s' requires elevation, but no elevator configured", plugin.name))
 		bot.Say(configElevError)
 		emit(ElevNoRunMisconfigured)
 		return ConfigurationError
@@ -30,34 +30,34 @@ func (bot *Robot) elevate(plugins []*Plugin, plugin *Plugin, immediate bool) (re
 		}
 		elevRet := callPlugin(bot, ePlug, false, false, "elevate", immedString)
 		if elevRet == Success {
-			Log(Audit, fmt.Sprintf("Elevation succeeded by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			Log(Audit, fmt.Sprintf("Elevation succeeded by elevator '%s', user '%s', plugin '%s' in channel '%s'", ePlug.name, bot.User, plugin.name, bot.Channel))
 			emit(ElevRanSuccess)
 			return Success
 		}
 		if elevRet == Fail {
-			Log(Audit, fmt.Sprintf("Elevation FAILED by elevator \"%s\", user \"%s\", plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			Log(Audit, fmt.Sprintf("Elevation FAILED by elevator '%s', user '%s', plugin '%s' in channel '%s'", ePlug.name, bot.User, plugin.name, bot.Channel))
 			bot.Say("Sorry, this command requires elevation")
 			emit(ElevRanFail)
 			return Fail
 		}
 		if elevRet == MechanismFail {
-			Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" mechanism failure while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			Log(Audit, fmt.Sprintf("Elevator plugin '%s' mechanism failure while elevating user '%s' for plugin '%s' in channel '%s'", ePlug.name, bot.User, plugin.name, bot.Channel))
 			bot.Say(technicalElevError)
 			emit(ElevRanMechanismFailed)
 			return MechanismFail
 		}
 		if elevRet == Normal {
-			Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" returned 'Normal' (0) instead of 'Success' (1), failing elevation in \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, bot.User, plugin.name, bot.Channel))
+			Log(Audit, fmt.Sprintf("Elevator plugin '%s' returned 'Normal' (0) instead of 'Success' (1), failing elevation in '%s' for plugin '%s' in channel '%s'", ePlug.name, bot.User, plugin.name, bot.Channel))
 			bot.Say(technicalElevError)
 			emit(ElevRanFailNormal)
 			return MechanismFail
 		}
-		Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" exit code %d while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", ePlug.name, retval, bot.User, plugin.name, bot.Channel))
+		Log(Audit, fmt.Sprintf("Elevator plugin '%s' exit code %d while elevating user '%s' for plugin '%s' in channel '%s'", ePlug.name, retval, bot.User, plugin.name, bot.Channel))
 		bot.Say(technicalElevError)
 		emit(ElevRanFailOther)
 		return MechanismFail
 	}
-	Log(Audit, fmt.Sprintf("Elevator plugin \"%s\" not found while elevating user \"%s\" for plugin \"%s\" in channel \"%s\"", plugin.Elevator, bot.User, plugin.name, bot.Channel))
+	Log(Audit, fmt.Sprintf("Elevator plugin '%s' not found while elevating user '%s' for plugin '%s' in channel '%s'", plugin.Elevator, bot.User, plugin.name, bot.Channel))
 	bot.Say(technicalElevError)
 	emit(ElevNoRunNotFound)
 	return ConfigurationError
@@ -91,6 +91,6 @@ func (bot *Robot) checkElevation(plugins []*Plugin, plugin *Plugin, command stri
 	if retval == Success {
 		return Success
 	}
-	Log(Error, fmt.Sprintf("Elevation failed for plugin \"%s\", command: \"%s\"", plugin.name, command))
+	Log(Error, fmt.Sprintf("Elevation failed for plugin '%s', command: '%s'", plugin.name, command))
 	return Fail
 }

--- a/bot/handler.go
+++ b/bot/handler.go
@@ -89,8 +89,10 @@ func (h handler) IncomingMessage(channelName, userName, messageFull, connector s
 		message = messageFull
 	}
 
+	directMsg := false
 	if len(channelName) == 0 { // true for direct messages
 		isCommand = true
+		directMsg = true
 		logChannel = "(direct message)"
 	}
 
@@ -104,6 +106,7 @@ func (h handler) IncomingMessage(channelName, userName, messageFull, connector s
 		RawMsg:    raw,
 		Format:    Variable,
 		isCommand: isCommand,
+		directMsg: directMsg,
 		msg:       message,
 	}
 	Log(Trace, fmt.Sprintf("Command \"%s\" in channel \"%s\"", message, logChannel))

--- a/bot/plugins.go
+++ b/bot/plugins.go
@@ -342,7 +342,7 @@ PlugLoop:
 
 		for key, value := range pcfgload {
 			var strval string
-			var boolval *bool
+			var boolval bool
 			var sarrval []string
 			var hval []PluginHelp
 			var mval []InputMatcher
@@ -383,46 +383,20 @@ PlugLoop:
 
 			switch key {
 			case "AllowDirect":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.AllowDirect = defaultAllowDirect
-				} else { // always honor explicit values, default when not specified given above
-					explicitAllowDirect = true
-					plugin.AllowDirect = *bptr
-				}
+				plugin.AllowDirect = *(val.(*bool))
+				explicitAllowDirect = true
 			case "DirectOnly":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.DirectOnly = false
-				} else {
-					plugin.DirectOnly = *bptr
-				}
+				plugin.DirectOnly = *(val.(*bool))
 			case "DenyDirect":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					denyDirect = false
-				} else {
-					r.Log(Warn, "Plugin '%s' uses deprecated 'DenyDirect'; use 'AllowDirect' instead")
-					explicitDenyDirect = true
-					denyDirect = *bptr
-				}
+				denyDirect = *(val.(*bool))
+				explicitDenyDirect = true
 			case "Channels":
 				plugin.Channels = *(val.(*[]string))
 			case "AllChannels":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.AllChannels = false
-				} else {
-					explicitAllChannels = true
-					plugin.AllChannels = *bptr
-				}
+				plugin.AllChannels = *(val.(*bool))
+				explicitAllChannels = true
 			case "RequireAdmin":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.RequireAdmin = false
-				} else {
-					plugin.RequireAdmin = *bptr
-				}
+				plugin.RequireAdmin = *(val.(*bool))
 			case "AdminCommands":
 				plugin.AdminCommands = *(val.(*[]string))
 			case "Elevator":
@@ -442,12 +416,7 @@ PlugLoop:
 			case "AuthorizedCommands":
 				plugin.AuthorizedCommands = *(val.(*[]string))
 			case "AuthorizeAllCommands":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.AuthorizeAllCommands = false
-				} else {
-					plugin.AuthorizeAllCommands = *bptr
-				}
+				plugin.AuthorizeAllCommands = *(val.(*bool))
 			case "Help":
 				plugin.Help = *(val.(*[]PluginHelp))
 			case "CommandMatchers":
@@ -457,12 +426,7 @@ PlugLoop:
 			case "MessageMatchers":
 				plugin.MessageMatchers = *(val.(*[]InputMatcher))
 			case "CatchAll":
-				bptr := *(val.(**bool))
-				if bptr == nil {
-					plugin.CatchAll = false
-				} else {
-					plugin.CatchAll = *bptr
-				}
+				plugin.CatchAll = *(val.(*bool))
 			case "Config":
 				plugin.Config = value
 			}
@@ -498,7 +462,13 @@ PlugLoop:
 		}
 
 		if explicitDenyDirect && !explicitAllowDirect {
+			Log(Debug, "Deprecated DenyDirect specified without AllowDirect; setting AllowDirect = !DenyDirect")
 			plugin.AllowDirect = !denyDirect
+			explicitAllowDirect = true
+		}
+		
+		if !explicitAllowDirect {
+			plugin.AllowDirect = defaultAllowDirect
 		}
 
 		// Use bot default plugin channels if none defined, unless AllChannels requested.

--- a/bot/plugins.go
+++ b/bot/plugins.go
@@ -298,7 +298,7 @@ PlugLoop:
 		} else {
 			if err := yaml.Unmarshal([]byte(pluginHandlers[plugin.name].DefaultConfig), &pcfgload); err != nil {
 				msg := fmt.Sprintf("Error unmarshalling default configuration, disabling: %v", err)
-				Log(Error, fmt.Errorf("Problem unmarshalling plugin default config for '%s', skipping: %v", plugin.name, err))
+				Log(Error, fmt.Errorf("Problem unmarshalling plugin default config for '%s', disabling: %v", plugin.name, err))
 				r.debug(plugin.pluginID, msg, false)
 				plugin.Disabled = true
 				plugin.reason = msg

--- a/bot/plugins.go
+++ b/bot/plugins.go
@@ -90,14 +90,12 @@ type plugType int
 const (
 	plugGo plugType = iota
 	plugExternal
-	plugBuiltin
-	disabled // for external plugin name collisions
 )
 
 // Plugin specifies the structure of a plugin configuration - plugins should include an example / default config
 type Plugin struct {
 	name                     string          // the name of the plugin, used as a key in to the
-	pluginType               plugType        // plugGo, plugExternal, plugBuiltin - determines how commands are routed
+	pluginType               plugType        // plugGo, plugExternal - determines how commands are routed
 	pluginPath               string          // Path to the external executable that expects <channel> <user> <command> <arg> <arg> from regex matches - for Plugtype=plugExternal only
 	Disabled                 bool            // Set true to disable the plugin
 	reason                   string          // why the plugin is disabled
@@ -213,9 +211,6 @@ func getPlugID(plug string) string {
 // Plugin configuration is initially loaded into temporary data structures,
 // then stored in the bot package under the global bot lock.
 func (r *Robot) loadPluginConfig() {
-	// pnames := make([]string, 0, 14)
-	// ptypes := make([]plugType, 0, 14)
-	// eppaths := make(map[string]string) // Paths to external plugins
 	plugIndexByID := make(map[string]int)
 	plugIndexByName := make(map[string]int)
 	plist := make([]*Plugin, 0, 14)
@@ -231,14 +226,6 @@ func (r *Robot) loadPluginConfig() {
 	robot.RUnlock() // we're done with bot data 'til the end
 
 	i := 0
-	// // builtins come first so indexes match, see loop below
-	// for _, plugname := range builtIns {
-	// 	plugin := &Plugin{name: plugname, pluginType: plugBuiltin, pluginID: getPlugID(plugname)}
-	// 	plist = append(plist, plugin)
-	// 	plugIndexByID[plugin.pluginID] = i
-	// 	plugIndexByName[plugin.name] = i
-	// 	i++
-	// }
 
 	for plugname := range pluginHandlers {
 		plugin := &Plugin{name: plugname, pluginType: plugGo, pluginID: getPlugID(plugname)}

--- a/bot/robot.go
+++ b/bot/robot.go
@@ -38,6 +38,7 @@ type Robot struct {
 	Format    MessageFormat // The outgoing message format, one of Fixed or Variable
 	pluginID  string        // Pass the ID in for later identificaton of the plugin
 	isCommand bool          // Was the message directed at the robot, dm or by mention
+	directMsg bool          // if the message was sent by DM
 	msg       string        // the message text sent
 }
 

--- a/conf/gopherbot.yaml.sample
+++ b/conf/gopherbot.yaml.sample
@@ -30,6 +30,10 @@
 ## defaults to no channels.
 #DefaultChannels: [ "general", "random" ]
 
+## Whether plugins are available by direct message by default if not specified;
+## defaults to true.
+#DefaultAllowDirect: true
+
 ## Users the bot should never listen to
 #IgnoreUsers: [ "otherbot", "slackbot" ]
 

--- a/connectors/terminal/connector.go
+++ b/connectors/terminal/connector.go
@@ -80,8 +80,8 @@ loop:
 					tc.Lock()
 					if newchan == "" {
 						tc.currentChannel = ""
-						tc.reader.Write([]byte("Changed current channel to: direct message\n"))
 						tc.reader.SetPrompt(fmt.Sprintf("c:(direct)/u:%s -> ", tc.currentUser))
+						tc.reader.Write([]byte("Changed current channel to: direct message\n"))
 					} else {
 						for _, ch := range tc.channels {
 							if ch == newchan {
@@ -90,9 +90,9 @@ loop:
 							}
 						}
 						if exists {
-							tc.reader.Write([]byte(fmt.Sprintf("Changed current channel to: %s\n", newchan)))
 							tc.currentChannel = newchan
 							tc.reader.SetPrompt(fmt.Sprintf("c:%s/u:%s -> ", tc.currentChannel, tc.currentUser))
+							tc.reader.Write([]byte(fmt.Sprintf("Changed current channel to: %s\n", newchan)))
 						} else {
 							tc.reader.Write([]byte("Invalid channel\n"))
 						}
@@ -112,8 +112,8 @@ loop:
 						}
 						if exists {
 							tc.currentUser = newuser
-							tc.reader.Write([]byte(fmt.Sprintf("Changed current user to: %s\n", newuser)))
 							tc.reader.SetPrompt(fmt.Sprintf("c:%s/u:%s -> ", tc.currentUser, tc.currentChannel))
+							tc.reader.Write([]byte(fmt.Sprintf("Changed current user to: %s\n", newuser)))
 						} else {
 							tc.reader.Write([]byte("Invalid user\n"))
 						}

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -19,7 +19,7 @@ Table of Contents
   * [Plugin Configuration](#plugin-configuration)
     * [Plugin Configuration Directives](#plugin-configuration-directives)
       * [Disabled](#disabled)
-      * [AllowDirect, DenyDirect, DirectOnly, Channels and AllChannels](#allowdirect-denydirect-directonly-channels-and-allchannels)
+      * [AllowDirect, DirectOnly, Channels and AllChannels](#allowdirect-directonly-channels-and-allchannels)
       * [CatchAll](#catchall)
       * [Users, RequireAdmin, AdminCommands](#users-requireadmin-admincommands)
       * [AuthorizedCommands, AuthorizeAllCommands, Authorizer and AuthRequire](#authorizedcommands-authorizeallcommands-authorizer-and-authrequire)
@@ -131,11 +131,11 @@ Individual plugins may be configured to require command authorization or elevati
 ### DefaultAllowDirect, DefaultChannels and JoinChannels
 
 ```yaml
-DefaultAllowDirect: true
+DefaultAllowDirect: true # default
 DefaultChannels: [ 'general', 'random' ]
 JoinChannels: [ 'security', 'infrastructure', 'lunch' ]
 ```
-DefaultAllowDirect sets a robot-wide default value for AllowDirect, indicating whether a plugin's commands are accessible via direct message. DefaultChannels specify which channels a plugin will be active in if the plugin doesn't explicitly list it's channels. JoinChannels specify the channels the robot will try to join when logging in (though this isn't supported in the Slack connector).
+DefaultAllowDirect sets a robot-wide default value for AllowDirect, indicating whether a plugin's commands are accessible via direct message; `true` if not otherwise specified. DefaultChannels specify which channels a plugin will be active in if the plugin doesn't explicitly list it's channels. JoinChannels specify the channels the robot will try to join when logging in (though this isn't supported in the Slack connector).
 
 ### ExternalPlugins
 
@@ -176,11 +176,10 @@ Disabled: true
 ```
 Useful for disabling compiled-in Go plugins.
 
-### AllowDirect, DenyDirect, DirectOnly, Channels and AllChannels
+### AllowDirect, DirectOnly, Channels and AllChannels
 
 ```yaml
-AllowDirect: false  # default
-DenyDirect: true    # default false, used when global DefaultAllowDirect = true
+AllowDirect: false  # only needed for overriding global DefaultAllowDirect
 DirectOnly: true    # default false
 ```
 ```yaml
@@ -191,7 +190,7 @@ Channels:
 ```yaml
 AllChannels: true
 ```
-`AllowDirect` and `DenyDirect` interact with the global value of `DefaultAllowDirect` to determine if a plugin is available via direct message. Plugin-level directives override the global setting, and `DenyDirect` overrides `AllowDirect` (if both are mistakenly set). DirectOnly indicates the plugin is ONLY available by direct message (private chat). To specify the channels a plugin is available in, you can list the channels explicitly or set `AllChannels` to true. If neither is specified, the plugin falls back to the robot's configured `DefaultChannels`.
+`AllowDirect` determines if a plugin is available via direct message, and is only needed to override the global value for `DefaultAllowDirect`. DirectOnly indicates the plugin is ONLY available by direct message (private chat), normally for security-sensitive commands. To specify the channels a plugin is available in, you can list the channels explicitly or set `AllChannels` to true. If neither is specified, the plugin falls back to the robot's configured `DefaultChannels`.
 
 ### CatchAll
 

--- a/doc/Plugin-Author's-Guide.md
+++ b/doc/Plugin-Author's-Guide.md
@@ -22,7 +22,7 @@ Table of Contents
     * [Authorization Plugins](#authorization-plugins)
     * [Elevation Plugins](#elevation-plugins)
   * [Using the Terminal Connector](#using-the-terminal-connector)
-    * [Using the Plugin Debugger](#plugin-debugging)
+  * [Plugin Debugging](#plugin-debugging)
   * [Getting Started](#getting-started)
     * [Starting from a Sample Plugin](#starting-from-a-sample-plugin)
     * [Using Boilerplate Code](#using-boilerplate-code)
@@ -142,9 +142,20 @@ random: @alice Adios
 [gopherbot]$
 ```
 
-## Plugin Debugging
-**Gopherbot** has a builtin command for plugin debugging that will send information about
-a plugin in direct messages. You can see plugin debugging in action here with
+# Plugin Debugging
+
+The most common problem a plugin author has is that they send their robot a message, but
+nothing happens or the robot just says `Sorry, that didn't match any commands I know, ...`.
+This can be due to a number of issues:
+* The plugin didn't load because of configuration problems
+* The robot isn't in the channel, and doesn't hear the message
+* The plugin isn't visible because of channel, user, or other restrictions
+* The user message doesn't match a regex for the plugin
+* The plugin runs, but does nothing
+
+**Gopherbot** has a builtin command for plugin debugging that can help quickly pinpoint
+most of these problems. Turning on plugin debugging will initiate a reload, then send debugging
+information about a plugin in direct messages. If `verbose` is enabled, You can see plugin debugging in action here with
 the terminal connector:
 ```
 [gopherbot]$ ./gopherbot

--- a/doc/Plugin-Author's-Guide.md
+++ b/doc/Plugin-Author's-Guide.md
@@ -156,57 +156,83 @@ This can be due to a number of issues:
 * The user message doesn't match a regex for the plugin
 * The plugin runs, but does nothing
 
+To track down these issues easily, **Gopherbot** has the builtin commands `debug plugin` and
+`dump plugin`.
+
 ## Debug Plugin Command
 **Gopherbot** has a builtin command for plugin debugging that can help quickly pinpoint
-most of these problems. Turning on plugin debugging will initiate a reload, then send debugging
+most problems. Turning on plugin debugging will initiate a reload, then send debugging
 information about a plugin in direct messages. If `verbose` is enabled, you will get debugging
 information for every message you send, or every command sent to the robot by another user.
-You can see plugin debugging in action here with the terminal connector:
+You can see an example of plugin debugging here with the terminal connector:
 ```
 [gopherbot]$ ./gopherbot
-2018/04/15 19:45:04 Initialized logging ...
-2018/04/15 19:45:04 Starting up with local config dir: /home/parse/.gopherbot, and install dir: /home/parse/go/src/github.com/lnxjedi/gopherbot
-2018/04/15 19:45:04 Debug: Loaded installed conf/gopherbot.yaml
-2018/04/15 19:45:04 Debug: Loaded configured conf/gopherbot.yaml
+2018/04/18 15:43:01 Initialized logging ...
+2018/04/18 15:43:01 Starting up with local config dir: /home/user/.gopherbot, and install dir: /home/user/go/src/github.com/lnxjedi/gopherbot
+2018/04/18 15:43:01 Debug: Loaded installed conf/gopherbot.yaml
+2018/04/18 15:43:01 Debug: Loaded configured conf/gopherbot.yaml
 Terminal connector running; Use '|C<channel>' to change channel, or '|U<user>' to change user
-c:general/u:parse -> ;ruby me!
-general: @parse Sorry, that didn't match any commands I know, or may refer to a command that's not available in this channel; try 'floyd, help <keyword>'
-c:random/u:parse -> ;help debug
-random: Command(s) matching keyword: debug
-floyd, debug plugin <pluginname> - turn on debugging for the named plugin
+c:general/u:alice -> ;ruby me!
+general: @alice Sorry, that didn't match any commands I know, or may refer to a command that's not available in this channel; try 'floyd, help <keyword>'
+c:general/u:alice -> ;help debug
+general: Command(s) matching keyword: debug
+floyd, debug plugin <pluginname> (verbose) - turn on debugging for the named plugin, optionally verbose
 
 floyd, stop debugging - turn off debugging
-c:general/u:parse -> ;debug plugin rubydemo
-(dm:parse): 2018/04/15 07:45:18 DEBUG rubydemo: Loaded default config from the plugin, size: 1417
-(dm:parse): 2018/04/15 07:45:18 DEBUG rubydemo: No configuration loaded from installPath (/home/parse/go/src/github.com/lnxjedi/gopherbot/conf/plugins/rubydemo.yaml): open /home/parse/go/src/github.com/lnxjedi/gopherbot/conf/plugins/rubydemo.yaml: no such file or directory
-(dm:parse): 2018/04/15 07:45:18 DEBUG rubydemo: Loaded configuration from configPath (/home/parse/.gopherbot/conf/plugins/rubydemo.yaml), size: 22
-general: Debugging enabled for rubydemo
-c:general/u:parse -> ;ruby me!
-(dm:parse): 2018/04/15 07:45:25 DEBUG rubydemo: plugin is NOT visible
-general: @parse Sorry, that didn't match any commands I know, or may refer to a command that's not available in this channel; try 'floyd, help <keyword>'
-c:general/u:parse -> |crandom
+c:general/u:alice -> ;debug plugin rubydemo
+(dm:alice): 2018/04/18 03:43:12 DEBUG rubydemo: Loaded default config from the plugin, size: 1417
+(dm:alice): 2018/04/18 03:43:12 DEBUG rubydemo: No configuration loaded from installPath (/home/alice/go/src/github.com/lnxjedi/gopherbot/conf/plugins/rubydemo.yaml): open /home/alice/go/src/github.com/lnxjedi/gopherbot/conf/plugins/rubydemo.yaml: no such file or directory
+(dm:alice): 2018/04/18 03:43:12 DEBUG rubydemo: Loaded configuration from configPath (/home/alice/.gopherbot/conf/plugins/rubydemo.yaml), size: 22
+(dm:alice): 2018/04/18 03:43:12 DEBUG rubydemo: Plugin 'rubydemo' will be active in channels ["random"]
+general: Debugging enabled for rubydemo (verbose: false)
+c:general/u:alice -> ;ruby me!
+(dm:alice): 2018/04/18 03:43:15 DEBUG rubydemo: plugin is NOT visible to user alice in channel general; channel 'general' is not on the list of allowed channels: random
+general: @alice Sorry, that didn't match any commands I know, or may refer to a command that's not available in this channel; try 'floyd, help <keyword>'
+c:general/u:alice -> |crandom
 Changed current channel to: random
-c:random/u:parse -> ;ruby me!
-(dm:parse): 2018/04/15 07:46:34 DEBUG rubydemo: Checking 7 command matchers against message: "ruby me!"
-(dm:parse): 2018/04/15 07:46:34 DEBUG rubydemo: Not matched: (?i:bashecho ([.;!\d\w-, ]+))
-(dm:parse): 2018/04/15 07:46:34 DEBUG rubydemo: Matched regex '(?i:ruby( me)?!?)', command: ruby
-(dm:parse): 2018/04/15 07:46:34 DEBUG rubydemo: Running plugin with command 'ruby' and arguments: [ me]
-random: Sure, David!
-random: Waaaaaait a second... what do you mean by that?
-(dm:parse): 2018/04/15 07:46:35 DEBUG rubydemo: Plugin finished with return value: Normal
-c:random/u:parse -> ;stop debugging
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Checking 7 command matchers against message: "stop debugging"
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:bashecho ([.;!\d\w-, ]+))
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:ruby( me)?!?)
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:listen( to me)?!?)
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:remember(?: (slowly))? ([-\w .,!?:\/]+))
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:recall ?([\d]+)?)
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:forget ([\d]{1,2}))
-(dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:check me)
-random: Debugging disabled
+c:random/u:alice -> ;ruby me to the max!
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: plugin is visible to user alice in channel random
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Checking 7 command matchers against message: "ruby me to the max!"
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:bashecho ([.;!\d\w-, ]+))
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:ruby( me)?!?)
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:listen( to me)?!?)
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:remember(?: (slowly))? ([-\w .,!?:\/]+))
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:recall ?([\d]+)?)
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:forget ([\d]{1,2}))
+(dm:alice): 2018/04/18 03:43:44 DEBUG rubydemo: Not matched: (?i:check me)
+random: @alice Sorry, that didn't match any commands I know, or may refer to a command that's not available in this channel; try 'floyd, help <keyword>'
+c:random/u:alice -> ;ruby me!
+(dm:alice): 2018/04/18 03:43:49 DEBUG rubydemo: plugin is visible to user alice in channel random
+(dm:alice): 2018/04/18 03:43:49 DEBUG rubydemo: Checking 7 command matchers against message: "ruby me!"
+(dm:alice): 2018/04/18 03:43:49 DEBUG rubydemo: Not matched: (?i:bashecho ([.;!\d\w-, ]+))
+(dm:alice): 2018/04/18 03:43:49 DEBUG rubydemo: Matched command regex '(?i:ruby( me)?!?)', command: ruby
+(dm:alice): 2018/04/18 03:43:49 DEBUG rubydemo: Running plugin with command 'ruby' and arguments: [ me]
+random: Sure, Alice!
+random: I'll ruby you, but not right now - I'll wait 'til you're least expecting it...
+(dm:alice): 2018/04/18 03:43:51 DEBUG rubydemo: Plugin finished with return value: Normal
 ```
 
 ## Dump Plugin Command
+To view a plugin's default or final configuration, you can use the `dump plugin` command:
+```
+c:general/u:alice -> ;help dump
+general: Command(s) matching keyword: dump
+floyd, dump plugin (default) <plugname> - dump the current or default configuration for the plugin (direct message only)
+
+floyd, dump robot - dump the current configuration for the robot (direct message only)
+c:general/u:alice -> |c
+Changed current channel to: direct message
+c:(direct)/u:alice -> dump plugin rubydemo
+(dm:alice): AdminCommands: null
+AllChannels: false
+AllowDirect: true
+AuthRequire: ""
+AuthorizeAllCommands: false
+AuthorizedCommands: null
+Authorizer: ""
+CatchAll: false
+... (MUCH more)
+```
 
 # Getting Started
 ## Starting from a Sample Plugin

--- a/doc/Plugin-Author's-Guide.md
+++ b/doc/Plugin-Author's-Guide.md
@@ -23,6 +23,8 @@ Table of Contents
     * [Elevation Plugins](#elevation-plugins)
   * [Using the Terminal Connector](#using-the-terminal-connector)
   * [Plugin Debugging](#plugin-debugging)
+    * [Debug Plugin Command](#debug-plugin-command)
+    * [Dump Plugin Command](#dump-plugin-command)
   * [Getting Started](#getting-started)
     * [Starting from a Sample Plugin](#starting-from-a-sample-plugin)
     * [Using Boilerplate Code](#using-boilerplate-code)
@@ -144,19 +146,22 @@ random: @alice Adios
 
 # Plugin Debugging
 
-The most common problem a plugin author has is that they send their robot a message, but
-nothing happens or the robot just says `Sorry, that didn't match any commands I know, ...`.
+The most common problem for plugin authors is the robot does nothing after sending it a message,
+or the robot just says `Sorry, that didn't match any commands I know, ...`.
+
 This can be due to a number of issues:
-* The plugin didn't load because of configuration problems
+* The plugin didn't load because of various configuration problems
 * The robot isn't in the channel, and doesn't hear the message
 * The plugin isn't visible because of channel, user, or other restrictions
 * The user message doesn't match a regex for the plugin
 * The plugin runs, but does nothing
 
+## Debug Plugin Command
 **Gopherbot** has a builtin command for plugin debugging that can help quickly pinpoint
 most of these problems. Turning on plugin debugging will initiate a reload, then send debugging
-information about a plugin in direct messages. If `verbose` is enabled, You can see plugin debugging in action here with
-the terminal connector:
+information about a plugin in direct messages. If `verbose` is enabled, you will get debugging
+information for every message you send, or every command sent to the robot by another user.
+You can see plugin debugging in action here with the terminal connector:
 ```
 [gopherbot]$ ./gopherbot
 2018/04/15 19:45:04 Initialized logging ...
@@ -200,6 +205,8 @@ c:random/u:parse -> ;stop debugging
 (dm:parse): 2018/04/15 07:47:02 DEBUG rubydemo: Not matched: (?i:check me)
 random: Debugging disabled
 ```
+
+## Dump Plugin Command
 
 # Getting Started
 ## Starting from a Sample Plugin


### PR DESCRIPTION
The plugin debugger will now tell you exactly why a plugin isn't visible, or why it's disabled.

All configured plugins now appear in 'list plugins'; instead of being skipped for errors, they're disabled instead. callPlugin.go checks that a plugin isn't disabled before trying to run it.

Authorization and Elevation plugins skip the pluginAvailable check when used for authorization and elevation; pluginAvailable is for visibility of commands, but shouldn't prevent an auth or elev plugin from being used for their intended purpose.